### PR TITLE
fix(ci): migrate workflow from adopt to temurin

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: ${{ env.JAVA_VERSION }}
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: 'maven'
 
     - name: Compile and verify with Maven


### PR DESCRIPTION
> **NOTE:** Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Adopt

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/171)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Java runtime in our build process to a new, standardized distribution, ensuring improved consistency and reliability during application builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->