### PR TITLE
chore(claude): improve Claude Code integration

### DIFF
--- a/.claude/commands/precommit.md
+++ b/.claude/commands/precommit.md
@@ -1,0 +1,7 @@
+Run the pre-commit checklist for this project:
+
+1. Remind me to update `CHANGELOG.md` `[Unreleased]` section (Added / Changed / Fixed / Removed) — I must do this manually.
+2. Run `./mvnw clean install` — must succeed with no compilation warnings and all tests passing.
+3. Remind me to open `target/site/jacoco/index.html` to verify coverage after the build completes.
+
+Run step 2, report the results clearly, then propose a branch name and commit message for my approval using the format `type(scope): description (#issue)` (max 80 chars; types: `feat` `fix` `chore` `docs` `test` `refactor` `ci` `perf`). Do not create the branch or commit until I explicitly confirm.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./mvnw *)"
+    ]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,5 +120,5 @@ Example: `feat(api): add player stats endpoint (#42)`
 ```text
 feat(scope): description (#issue)
 
-Co-authored-by: Claude <noreply@anthropic.com>
+Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 HELP.md
+.claude/settings.local.json
 target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -14,7 +14,7 @@
     "vscjava.vscode-spring-initializr",  // Spring Initializr - Generate Spring Boot projects
 
     // AI Assistance
-    "github.copilot-chat",               // GitHub Copilot Chat - AI-powered coding assistant
+    "anthropic.claude-code",             // Claude Code - AI-powered coding assistant
     "coderabbit.coderabbit-vscode",      // CodeRabbit - AI-powered code review
 
     // Code Quality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+@.github/copilot-instructions.md
+
+## Claude Code
+
+- Run `/precommit` to execute the full pre-commit checklist for this project.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` importing `.github/copilot-instructions.md` with a `## Claude Code` section pointing to `/precommit`
- Add `.claude/settings.json` with `./mvnw *` tool permissions
- Add `.claude/commands/precommit.md` with the full pre-commit checklist as a `/precommit` slash command
- Replace `github.copilot-chat` with `anthropic.claude-code` in `.vscode/extensions.json`
- Fix co-author in `copilot-instructions.md` to `Claude Sonnet 4.6`
- Add `.claude/settings.local.json` to `.gitignore`

## Notes

`.claude/settings.json` and `.claude/commands/` are committed intentionally — they contain no secrets and are useful for any contributor using Claude Code. `.claude/settings.local.json` remains gitignored for machine-specific overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/284)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Claude Code integration guide with pre-commit workflow instructions.

* **Chores**
  * Added pre-commit validation configuration and checklist.
  * Updated IDE extension recommendations.
  * Enhanced development environment settings and templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->