### PR TITLE
docs(changelog): prepare release notes for v2.0.0-barcelona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ Release names follow the **historic football clubs** naming convention (A–Z):
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+---
+
+## [2.0.0 - Barcelona] - 2026-04-06
+
 ### Changed
 
 - Normalize data-state vocabulary in BDD-style test names: rename 12 `given*`
@@ -66,6 +78,10 @@ Release names follow the **historic football clubs** naming convention (A–Z):
 - `PUT /players/{squadNumber}` and `DELETE /players/{squadNumber}`: path
   variable changed from `Long id` to `Integer squadNumber` (#268)
 - `GET /players/{id}`: path variable changed from `Long` to `UUID` (#268)
+
+  **BREAKING CHANGE**: `PUT /players/{id}` and `DELETE /players/{id}` routes
+  replaced by `PUT /players/{squadNumber}` and `DELETE /players/{squadNumber}`;
+  `GET /players/{id}` path variable type changed from `Long` to `UUID` (#268)
 - `storage/players-sqlite3.db`: schema migrated to `id VARCHAR(36) PRIMARY KEY`,
   `squadNumber INTEGER NOT NULL UNIQUE`; 25 players preserved (#268)
 - `ddl.sql` and `dml.sql`: test schema and seed data updated for new structure (#268)

--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ Interactive API documentation is available via Swagger UI at `http://localhost:9
 | Method | Endpoint | Description | Status |
 | ------ | -------- | ----------- | ------ |
 | `GET` | `/players` | List all players | `200 OK` |
-| `GET` | `/players/{id}` | Get player by ID | `200 OK` |
+| `GET` | `/players/{id}` | Get player by UUID | `200 OK` |
 | `GET` | `/players/search/league/{league}` | Search players by league | `200 OK` |
 | `GET` | `/players/squadnumber/{squadNumber}` | Get player by squad number | `200 OK` |
 | `POST` | `/players` | Create new player | `201 Created` |
-| `PUT` | `/players/{id}` | Update player by ID | `204 No Content` |
-| `DELETE` | `/players/{id}` | Remove player by ID | `204 No Content` |
+| `PUT` | `/players/{squadNumber}` | Update player by squad number | `204 No Content` |
+| `DELETE` | `/players/{squadNumber}` | Remove player by squad number | `204 No Content` |
 | `GET` | `/actuator/health` | Health check | `200 OK` |
 
 Error codes: `400 Bad Request` (validation failed) · `404 Not Found` (player not found) · `409 Conflict` (duplicate squad number on `POST`)


### PR DESCRIPTION
## Summary

- Promotes `[Unreleased]` to `[2.0.0 - Barcelona] - 2026-04-06`
- Adds `BREAKING CHANGE` marker to the #268 entry: `PUT /players/{id}` and `DELETE /players/{id}` replaced by `PUT /players/{squadNumber}` and `DELETE /players/{squadNumber}`; `GET /players/{id}` path variable changed from `Long` to `UUID`
- Fixes README API reference table: corrects `PUT` and `DELETE` endpoint paths/descriptions to `{squadNumber}`, and `GET /players/{id}` description to "by UUID"

## What's in this release

### Changed

- UUID primary key + squad number as natural-key route identifier for `PUT` and `DELETE` (#268)
- Player dataset normalized to November 2022 World Cup squads; test fixtures aligned (#288)
- BDD test name vocabulary normalized (`existing` / `nonexistent` / `unknown`) (#303)

### Added

- Repository delete test covering Lo Celso inline save + delete pattern (#288)
- JaCoCo `check` goal enforcing 80% instruction and branch coverage (#268)

## Test plan

- [ ] CI is green
- [ ] `./mvnw clean install` passes (40/40 tests, all coverage checks met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/305)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Players API documentation to reflect version 2.0.0 changes
  * GET /players/{id} now uses UUID-based lookups
  * PUT and DELETE operations now use squad number parameter instead of ID
  * Added breaking change notice in changelog

<!-- end of auto-generated comment: release notes by coderabbit.ai -->