### PR TITLE
chore(docker): switch runtime to `eclipse-temurin:25-jre-alpine` (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ Release names follow the **historic football clubs** naming convention (A–Z):
 
 ### Changed
 
+- Switch runtime base image from `eclipse-temurin:25-jdk-alpine` to
+  `eclipse-temurin:25-jre-alpine` to reduce image size by dropping compiler
+  toolchain (`javac`, `jshell`, debug utilities) while retaining the full JVM
+  (#307)
+
 ### Fixed
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mvn clean package -DskipTests
 # Stage 2: Runtime
 # This stage creates the final, minimal image to run the application.
 # ------------------------------------------------------------------------------
-FROM eclipse-temurin:25-jdk-alpine AS runtime
+FROM eclipse-temurin:25-jre-alpine AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Switches the runtime base image from `eclipse-temurin:25-jdk-alpine` to `eclipse-temurin:25-jre-alpine`, dropping the compiler toolchain (`javac`, `jshell`, debug utilities) while retaining the full JVM

Closes #307

## Test plan

- [x] `./mvnw clean install` passes
- [x] All 40 tests pass
- [x] `docker compose down -v && docker compose build && docker compose up` — container starts, health check goes green, API responds on port 9000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/309)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized container runtime image by removing unnecessary development tools while maintaining full JVM functionality, resulting in a smaller and more efficient runtime footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->