### PR TITLE
ci(cd): verify tag commit is reachable from master (#292)

### DIFF
--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -43,6 +43,14 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - name: Verify tag commit is reachable from master
+              run: |
+                  if ! git branch -r --contains "${{ github.sha }}" | grep -q "origin/master"; then
+                    echo "❌ Tag commit ${{ github.sha }} is not reachable from origin/master"
+                    exit 1
+                  fi
+                  echo "✅ Tag commit ${{ github.sha }} is reachable from origin/master"
+
             - name: Extract and validate tag components
               id: tag
               run: |

--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -45,7 +45,7 @@ jobs:
 
             - name: Verify tag commit is reachable from master
               run: |
-                  if ! git branch -r --contains "${{ github.sha }}" | grep -q "origin/master"; then
+                  if ! git merge-base --is-ancestor "${{ github.sha }}" origin/master; then
                     echo "❌ Tag commit ${{ github.sha }} is not reachable from origin/master"
                     exit 1
                   fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Release names follow the **historic football clubs** naming convention (A–Z):
   in-memory with `ddl.sql`/`dml.sql`; switch `spring.jpa.hibernate.ddl-auto`
   from `none` to `validate` so Hibernate verifies entity mappings against the
   Flyway-managed schema (#130)
+- Add runtime verification step to the CD workflow that checks whether the tag
+  commit is reachable from `origin/master` before proceeding with build and
+  publish steps, preventing accidental releases from unmerged branches (#292)
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Adds a **"Verify tag commit is reachable from master"** step to the `release` job in `.github/workflows/maven-cd.yml`
- Placed immediately after "Checkout repository" and before "Extract and validate tag components"
- Uses `git branch -r --contains ${{ github.sha }}` to check that the tag commit is an ancestor of `origin/master`; fails with a descriptive error if not

## Test plan

- [ ] Workflow passes on a valid release tag pushed from a merged commit
- [ ] Workflow fails early with `❌ Tag commit ... is not reachable from origin/master` if the tag points to an unmerged commit

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/313)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release verification process to ensure code integrity and prevent unintended releases from unmerged branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->