### PR TITLE
docs(changelog): add release template and reference links (#317)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,3 +132,32 @@ Release names follow the **historic football clubs** naming convention (A–Z):
 ## [1.0.0 - Arsenal] - 2026-03-29
 
 Initial release. See [README.md](README.md) for complete feature list and documentation.
+
+<!-- Template for new releases:
+
+## [X.Y.Z - CLUB_NAME] - YYYY-MM-DD
+
+### Added
+- New features
+
+### Changed
+- Changes in existing functionality
+
+### Deprecated
+- Soon-to-be removed features
+
+### Removed
+- Removed features
+
+### Fixed
+- Bug fixes
+
+### Security
+- Security vulnerability fixes
+
+-->
+
+[unreleased]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.1-chelsea...HEAD
+[2.0.1 - Chelsea]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.0-barcelona...v2.0.1-chelsea
+[2.0.0 - Barcelona]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v1.0.0-arsenal...v2.0.0-barcelona
+[1.0.0 - Arsenal]: https://github.com/nanotaboada/java.samples.spring.boot/releases/tag/v1.0.0-arsenal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ Initial release. See [README.md](README.md) for complete feature list and docume
 
 -->
 
-[unreleased]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.1-chelsea...HEAD
+[Unreleased]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.1-chelsea...HEAD
 [2.0.1 - Chelsea]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.0-barcelona...v2.0.1-chelsea
 [2.0.0 - Barcelona]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v1.0.0-arsenal...v2.0.0-barcelona
 [1.0.0 - Arsenal]: https://github.com/nanotaboada/java.samples.spring.boot/releases/tag/v1.0.0-arsenal


### PR DESCRIPTION
## Summary

- Add `<!-- Template for new releases: -->` comment block after the last release entry
- Add reference links at the bottom for all four releases plus `[Unreleased]`

## Test plan

- [ ] No other content changed
- [ ] Reference links point to correct GitHub compare/tag URLs

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/325)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a standardized changelog entry template specifying version header format and standard sections (Added/Changed/Deprecated/Removed/Fixed/Security).
  * Added GitHub reference links for "Unreleased" and existing version entries so past and future release references resolve within the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->