### PR TITLE
docs(changelog): prepare release notes for v2.0.2-dortmund

### DIFF
--- a/.claude/commands/pre-release.md
+++ b/.claude/commands/pre-release.md
@@ -58,7 +58,15 @@ proceeding. Never create a branch, commit, tag, or push without approval.
      - `[unreleased]` → `.../compare/vX.Y.Z-{club}...HEAD`
      - Add `[X.Y.Z - ClubName]` → `.../compare/v{prev-tag}...vX.Y.Z-{club}`
 
-3. Show the full diff of `CHANGELOG.md` and propose this commit message:
+3. Show the full diff of `CHANGELOG.md`.
+
+4. If `coderabbit` CLI is installed, run `coderabbit review --type uncommitted --prompt-only`
+   on the uncommitted CHANGELOG changes:
+   - If actionable/serious findings are reported, stop and address them before proceeding.
+   - If only nitpick-level findings, report them and continue.
+   - If `coderabbit` is not installed, skip with a note.
+
+5. Propose this commit message:
 
    ```text
    docs(changelog): prepare release notes for vX.Y.Z-{club} (#issue)
@@ -66,17 +74,20 @@ proceeding. Never create a branch, commit, tag, or push without approval.
 
    **Wait for explicit approval before committing.**
 
-4. Run `/pre-commit`, manually skipping step 1 — do not re-run or re-attempt
-   the CHANGELOG update; it was already completed above. Open with: "Skip
-   step 1 — CHANGELOG was already updated as part of this release branch."
-   Proceed directly with steps 2–4.
+6. Run `./mvnw clean install` — must succeed with no compilation warnings, all
+   tests passing, and the JaCoCo check reporting `All coverage checks have been met.`
 
-5. Propose opening a PR from `release/vX.Y.Z-{club}` into `master`.
+7. If Docker is running, run `docker compose build` — must succeed with no errors.
+   Skip with a note if Docker Desktop is not running.
+
+8. Stage `CHANGELOG.md` and commit using the approved message from step 5.
+
+9. Propose opening a PR from `release/vX.Y.Z-{club}` into `master`.
    **Wait for explicit approval before opening.**
 
-6. Open the PR with:
-   - Title: `docs(changelog): prepare release notes for vX.Y.Z-{club}`
-   - Body summarising what is included in this release.
+10. Open the PR with:
+    - Title: `docs(changelog): prepare release notes for vX.Y.Z-{club}`
+    - Body summarising what is included in this release.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,16 +44,28 @@ Release names follow the **historic football clubs** naming convention (A–Z):
 
 ### Changed
 
+- Refactor `/pre-release` Phase 2: inline build and test steps directly
+  (`./mvnw clean install`, `docker compose build`) instead of delegating to
+  `/pre-commit`; move CodeRabbit review to run against the uncommitted CHANGELOG
+  diff; separate commit-message approval from the actual commit so checks run
+  in between
+
+### Fixed
+
+### Removed
+
+---
+
+## [2.0.2 - Borussia Dortmund] - 2026-04-27
+
+### Changed
+
 - Return `422 Unprocessable Entity` for field validation failures (`@Valid`
   constraint violations and squad number mismatch) instead of `400 Bad Request`;
   reserve `400` for genuinely malformed requests (unparseable JSON, wrong
   `Content-Type`); introduce `GlobalExceptionHandler` (`@ControllerAdvice`) to
   intercept `MethodArgumentNotValidException`; update OpenAPI `@ApiResponse`
   annotations and test assertions accordingly (#319)
-
-### Fixed
-
-### Removed
 
 ---
 
@@ -164,7 +176,8 @@ Initial release. See [README.md](README.md) for complete feature list and docume
 
 -->
 
-[Unreleased]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.1-chelsea...HEAD
+[Unreleased]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.2-dortmund...HEAD
+[2.0.2 - Borussia Dortmund]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.1-chelsea...v2.0.2-dortmund
 [2.0.1 - Chelsea]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v2.0.0-barcelona...v2.0.1-chelsea
 [2.0.0 - Barcelona]: https://github.com/nanotaboada/java.samples.spring.boot/compare/v1.0.0-arsenal...v2.0.0-barcelona
 [1.0.0 - Arsenal]: https://github.com/nanotaboada/java.samples.spring.boot/releases/tag/v1.0.0-arsenal


### PR DESCRIPTION
## Summary

- Promotes `422 Unprocessable Entity` validation change (#319) into release `v2.0.2-dortmund`
- Refactors `/pre-release` Phase 2: inlines build/test steps directly, moves CodeRabbit review to run against the uncommitted CHANGELOG diff, and separates commit-message approval from the actual commit

## Test plan

- [ ] CI passes
- [ ] CHANGELOG diff looks correct
- [ ] Merge into `master`, then tag `v2.0.2-dortmund`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/327)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with Phase 2 workflow restructuring details.

* **Chores**
  * Enhanced pre-release workflow with improved build verification steps and streamlined review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->