### PR TITLE
docs(claude): add required prefix, base package, and single-test commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,17 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 @.github/copilot-instructions.md
 
 ## Claude Code
 
 - Run `/pre-commit` to execute the full pre-commit checklist for this project.
+- Base package: `ar.com.nanotaboada.java.samples.spring.boot` — all source lives under this path.
+
+### Running a single test
+
+```bash
+./mvnw test -Dtest=PlayersControllerTests          # one test class
+./mvnw test -Dtest=PlayersServiceTests#givenX_whenY_thenZ  # one test method
+```


### PR DESCRIPTION
## Summary

- Added required Claude Code guidance prefix to `CLAUDE.md`
- Added base package path (`ar.com.nanotaboada.java.samples.spring.boot`) for easier navigation
- Added commands for running a single test class or method via `-Dtest=`

## Test plan

- [ ] No code changes — docs only, no tests required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/330)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with clearer repository guidance, information about Java source locations, and comprehensive test execution examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanotaboada/java.samples.spring.boot/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->