### PR TITLE
fix(docs): add top-level heading to skill files (MD041)

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -3,6 +3,8 @@ name: create-issue
 description: Draft a GitHub Issue as the spec artifact for Spec-Driven Development (SDD) before implementing a feature or bug fix in this project.
 ---
 
+# Create an issue
+
 This project uses Spec-Driven Development (SDD): discuss in Plan mode first, create a GitHub Issue as the spec artifact, then implement. Always offer to draft an issue before writing code.
 
 **Feature request** (`enhancement` label):

--- a/.claude/skills/key-workflows/SKILL.md
+++ b/.claude/skills/key-workflows/SKILL.md
@@ -3,6 +3,8 @@ name: key-workflows
 description: Step-by-step guides for adding an endpoint or modifying the schema in this Spring Boot project, plus the branch/commit proposal to make after finishing work.
 ---
 
+# Key workflows
+
 **Add an endpoint**: Define DTO in `models/` with Bean Validation → add service method in `services/` with `@Transactional` → create controller endpoint with `@Operation` annotation → add tests → run `./mvnw clean test jacoco:report`.
 
 **Modify schema**: Create a new Flyway migration `src/main/resources/db/migration/V{N}__description.sql` (production path) → update `@Entity` in `models/Player.java` → update DTOs if API changes → also update `src/test/resources/ddl.sql` and `dml.sql` (tests use Spring SQL init, not Flyway) → update service, repository, and tests → run `./mvnw clean test`. Do not manually edit the SQLite file in `storage/`; Flyway owns it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ Release names follow the **historic football clubs** naming convention (A–Z):
 
 ### Fixed
 
+- Add top-level Markdown heading to `create-issue` and `key-workflows` skill
+  files to resolve MD041 (first-line-heading) — flagged by CodeRabbit on #355
+
 ### Removed
 
 ---


### PR DESCRIPTION
## Summary
- Add a top-level Markdown heading ("# Create an issue" / "# Key workflows") as the first line of content after the YAML front matter in both new skill files
- Resolves the MD041 (first-line-heading) markdownlint warning CodeRabbit flagged on #355

No backing GitHub Issue — follow-up fix for a review comment on an already-merged PR.

## Test plan
- [x] Both skill files now start with a top-level heading immediately after front matter
- [x] No code, API, or CI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/java.samples.spring.boot/356)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear top-level headings to the issue creation and key workflow guides.
  * Updated the unreleased changelog to document these documentation improvements.
  * Resolved Markdown formatting warnings related to missing first-line headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->